### PR TITLE
Ensure that all MediaType annotations put XML before json.

### DIFF
--- a/zanata-common-api/src/main/java/org/zanata/rest/client/ITranslatedDocResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/client/ITranslatedDocResource.java
@@ -44,8 +44,8 @@ import static org.zanata.rest.service.SourceDocResource.RESOURCE_SLUG_TEMPLATE;
 /**
  * Client Interface for the Translation Resources service.
  */
-@Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
-@Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+@Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+@Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
 public interface ITranslatedDocResource extends TranslatedDocResource {
     @GET
     @Path(RESOURCE_SLUG_TEMPLATE + "/translations/{locale}")

--- a/zanata-common-api/src/main/java/org/zanata/rest/client/IVersionResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/client/IVersionResource.java
@@ -39,8 +39,8 @@ import javax.ws.rs.core.MediaType;
 public interface IVersionResource extends VersionResource {
     @Override
     @GET
-    @Produces({ MediaTypes.APPLICATION_ZANATA_VERSION_JSON,
-            MediaTypes.APPLICATION_ZANATA_VERSION_XML })
+    @Produces({ MediaTypes.APPLICATION_ZANATA_VERSION_XML,
+                MediaTypes.APPLICATION_ZANATA_VERSION_JSON })
     public ClientResponse<VersionInfo> get();
 
 }

--- a/zanata-common-api/src/main/java/org/zanata/rest/enunciate/TranslatedDocResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/enunciate/TranslatedDocResource.java
@@ -7,8 +7,8 @@ import javax.ws.rs.core.MediaType;
 
 @Path(TranslatedDocResource.SERVICE_PATH)
 @org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle
-@Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
-@Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+@Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+@Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
 interface TranslatedDocResource extends
         org.zanata.rest.service.TranslatedDocResource {
 }

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/TranslatedDocResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/TranslatedDocResource.java
@@ -51,8 +51,8 @@ import static org.zanata.rest.service.SourceDocResource.RESOURCE_SLUG_TEMPLATE;
  *         href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
  *
  */
-@Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
-@Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+@Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+@Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
 public interface TranslatedDocResource {
     public static final String SERVICE_PATH =
             ProjectIterationResource.SERVICE_PATH + "/r";

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/VersionResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/VersionResource.java
@@ -49,8 +49,8 @@ public interface VersionResource {
      *         the server while performing this operation.
      */
     @GET
-    @Produces({ MediaTypes.APPLICATION_ZANATA_VERSION_JSON,
-            MediaTypes.APPLICATION_ZANATA_VERSION_XML })
+    @Produces({ MediaTypes.APPLICATION_ZANATA_VERSION_XML,
+                MediaTypes.APPLICATION_ZANATA_VERSION_JSON })
     @TypeHint(VersionInfo.class)
     public Response get();
 


### PR DESCRIPTION
```
The cli client was requesting json for version because it was
first in the list, then was not prepared to parse it. This
change ensures that the client will request xml to avoid the
json parsing issue.
```
