### PR TITLE
Fix wrong calculation of remaining hours

### DIFF
--- a/zanata-common-api/src/main/java/org/zanata/rest/dto/stats/TranslationStatistics.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/dto/stats/TranslationStatistics.java
@@ -101,9 +101,8 @@ public class TranslationStatistics implements Serializable {
         if (unit.equals(StatUnit.WORD)) {
             double untransHours = translationCount.getUntranslated() / 250.0;
             double fuzzyHours = translationCount.getNeedReview() / 500.0;
-            double translatedHours = translationCount.getTranslated() / 500.0;
 
-            remainingHours = untransHours + fuzzyHours + translatedHours;
+            remainingHours = untransHours + fuzzyHours;
         }
     }
 


### PR DESCRIPTION
Fix wrong calculation of remaining hours, 
remove translated count from the equation. 
