### PR TITLE
Add a new parameter includeAutomatedEntry to API getContributionStatics

### DIFF
--- a/zanata-common-api/src/main/java/org/zanata/rest/service/StatisticsResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/StatisticsResource.java
@@ -133,6 +133,9 @@ public interface StatisticsResource {
      * @param dateRange
      *            date range from..to (yyyy-mm-dd..yyyy-mm-dd)
      *
+     * @param includeAutomatedEntry
+     *            whether to include automatic entries of translation into statistic
+     *
      * @return The following response status codes will be returned from this
      *         operation:<br>
      *         OK(200) - Response containing contribution statistics for the
@@ -151,7 +154,9 @@ public interface StatisticsResource {
                     @PathParam("projectSlug") String projectSlug,
                     @PathParam("versionSlug") String versionSlug,
                     @PathParam("username") String username,
-                    @PathParam("dateRange") String dateRange
+                    @PathParam("dateRange") String dateRange,
+                    @QueryParam("includeAutomatedEntry")
+                    @DefaultValue("false") boolean includeAutomatedEntry
             );
 
 }


### PR DESCRIPTION
It's a related patch to https://github.com/zanata/zanata-server/pull/1029.

Add a new parameter to getContributionStatistic API.
The parameter is a boolean type to control whether to include automatic entries of translation into statistic.