### PR TITLE
Add @Path annotations to REST interfaces

### DIFF
--- a/zanata-common-api/src/main/java/org/zanata/rest/service/AccountResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/AccountResource.java
@@ -24,10 +24,12 @@ package org.zanata.rest.service;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.zanata.rest.MediaTypes;
 import org.zanata.rest.dto.Account;
 
@@ -38,7 +40,9 @@ import org.zanata.rest.dto.Account;
  *         href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
  *
  */
-public interface AccountResource {
+@Path(AccountResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
+public interface AccountResource extends RestResource {
     public static final String SERVICE_PATH =
             "/accounts/u/{username:[a-z\\d_]{3,20}}";
 

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/AsynchronousProcessResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/AsynchronousProcessResource.java
@@ -34,6 +34,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.zanata.common.LocaleId;
 import org.zanata.rest.dto.ProcessStatus;
 import org.zanata.rest.dto.resource.Resource;
@@ -46,9 +47,11 @@ import org.zanata.rest.dto.resource.TranslationsResource;
  * @author Carlos Munoz <a
  *         href="mailto:camunoz@redhat.com">camunoz@redhat.com</a>
  */
+@Path(AsynchronousProcessResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-public interface AsynchronousProcessResource {
+public interface AsynchronousProcessResource extends RestResource {
     public static final String SERVICE_PATH = "/async";
 
     /**

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/CopyTransResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/CopyTransResource.java
@@ -29,15 +29,18 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.zanata.rest.dto.CopyTransStatus;
 
 /**
  * @author Carlos Munoz <a
  *         href="mailto:camunoz@redhat.com">camunoz@redhat.com</a>
  */
+@Path(CopyTransResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-public interface CopyTransResource {
+public interface CopyTransResource extends RestResource {
     public static final String SERVICE_PATH = "/copytrans";
 
     /**

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/FileResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/FileResource.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 import org.zanata.common.DocumentType;
 import org.zanata.rest.DocumentFileUploadForm;
@@ -41,9 +42,11 @@ import org.zanata.rest.dto.ChunkUploadResponse;
 /**
  * Interface for file upload and download REST methods.
  */
+@Path(FileResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Produces({ MediaType.APPLICATION_OCTET_STREAM })
 @Consumes({ MediaType.APPLICATION_OCTET_STREAM })
-public interface FileResource {
+public interface FileResource extends RestResource {
     public static final String SERVICE_PATH = "/file";
     @Deprecated
     public static final String FILE_RESOURCE = SERVICE_PATH;

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/GlossaryResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/GlossaryResource.java
@@ -35,6 +35,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 import org.zanata.common.LocaleId;
 import org.zanata.rest.GlossaryFileUploadForm;
@@ -49,13 +50,15 @@ import org.zanata.rest.dto.ResultList;
  * @author Alex Eng <a href="mailto:aeng@redhat.com">aeng@redhat.com</a>
  *
  **/
+@Path(GlossaryResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON,
         MediaTypes.APPLICATION_ZANATA_GLOSSARY_XML,
         MediaTypes.APPLICATION_ZANATA_GLOSSARY_JSON })
 @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON,
         MediaTypes.APPLICATION_ZANATA_GLOSSARY_XML,
         MediaTypes.APPLICATION_ZANATA_GLOSSARY_JSON })
-public interface GlossaryResource {
+public interface GlossaryResource extends RestResource {
     public static final String SERVICE_PATH = "/glossary";
 
     /**

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/ProjectIterationLocalesResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/ProjectIterationLocalesResource.java
@@ -22,16 +22,20 @@
 package org.zanata.rest.service;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.zanata.rest.MediaTypes;
 import org.zanata.rest.dto.LocaleDetails;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+@Path(ProjectIterationLocalesResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-public interface ProjectIterationLocalesResource {
+public interface ProjectIterationLocalesResource extends RestResource {
     public static final String SERVICE_PATH = ProjectIterationResource.SERVICE_PATH
             + "/locales";
 

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/ProjectIterationResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/ProjectIterationResource.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.zanata.rest.MediaTypes;
 import org.zanata.rest.dto.ProjectIteration;
 
@@ -44,10 +45,12 @@ import org.zanata.rest.dto.ProjectIteration;
  *         href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
  *
  */
+@Path(ProjectIterationResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Deprecated
 @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-public interface ProjectIterationResource {
+public interface ProjectIterationResource extends RestResource {
     public static final String ITERATION_SLUG_TEMPLATE = "{iterationSlug:"
             + RestConstants.SLUG_PATTERN + "}";
     public static final String SERVICE_PATH = ProjectResource.SERVICE_PATH

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/ProjectLocalesResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/ProjectLocalesResource.java
@@ -22,16 +22,20 @@
 package org.zanata.rest.service;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.zanata.rest.MediaTypes;
 import org.zanata.rest.dto.LocaleDetails;
 
+@Path(ProjectLocalesResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-public interface ProjectLocalesResource {
+public interface ProjectLocalesResource extends RestResource {
     public static final String SERVICE_PATH = ProjectResource.SERVICE_PATH
             + "/locales";
 

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/ProjectResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/ProjectResource.java
@@ -25,11 +25,13 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
 import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.zanata.rest.MediaTypes;
 import org.zanata.rest.dto.Project;
 
@@ -40,9 +42,11 @@ import org.zanata.rest.dto.Project;
  *         href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
  *
  */
+@Path(ProjectResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-public interface ProjectResource {
+public interface ProjectResource extends RestResource {
     public static final String PROJECT_SLUG_TEMPLATE = "{projectSlug:"
             + RestConstants.SLUG_PATTERN + "}";
     public static final String SERVICE_PATH = "/projects/p/"

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/ProjectVersionResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/ProjectVersionResource.java
@@ -22,6 +22,7 @@
 package org.zanata.rest.service;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.zanata.rest.MediaTypes;
 import org.zanata.rest.dto.LocaleDetails;
 import org.zanata.rest.dto.ProjectIteration;
@@ -46,9 +47,11 @@ import javax.ws.rs.core.Response;
  *
  * @author Alex Eng <a href="mailto:aeng@redhat.com">aeng@redhat.com</a>
  */
+@Path(ProjectVersionResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-public interface ProjectVersionResource {
+public interface ProjectVersionResource extends RestResource {
     public static final String PROJECT_SERVICE_PATH = "/project";
 
     public static final String VERSION_SLUG_TEMPLATE = "/{versionSlug:"

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/ProjectsResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/ProjectsResource.java
@@ -23,11 +23,13 @@ package org.zanata.rest.service;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.jboss.resteasy.annotations.providers.jaxb.Wrapped;
 import org.zanata.common.Namespaces;
 import org.zanata.rest.MediaTypes;
@@ -38,9 +40,11 @@ import org.zanata.rest.dto.Project;
  *         href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
  *
  */
+@Path(ProjectsResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-public interface ProjectsResource {
+public interface ProjectsResource extends RestResource {
     public static final String SERVICE_PATH = "/projects";
 
     /**

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/RestResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/RestResource.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.zanata.rest.service;
+
+/**
+ * Marker interface for REST Resource classes (used by org.zanata.util.JaxRSClassIndexProcessor)
+ *
+ * @author Sean Flanigan <a
+ *         href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
+ *
+ */
+public interface RestResource {
+}

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/SourceDocResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/SourceDocResource.java
@@ -21,6 +21,7 @@
 package org.zanata.rest.service;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.jboss.resteasy.annotations.providers.jaxb.Wrapped;
 import org.zanata.common.Namespaces;
 import org.zanata.rest.dto.resource.Resource;
@@ -48,9 +49,11 @@ import java.util.Set;
  * @author Carlos Munoz <a
  *         href="mailto:camunoz@redhat.com">camunoz@redhat.com</a>
  */
+@Path(SourceDocResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-public interface SourceDocResource {
+public interface SourceDocResource extends RestResource {
     String SERVICE_PATH =
             ProjectIterationResource.SERVICE_PATH + "/r";
     String RESOURCE_SLUG_REGEX =

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/StatisticsResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/StatisticsResource.java
@@ -30,6 +30,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.zanata.rest.dto.stats.ContainerTranslationStatistics;
 import org.zanata.rest.dto.stats.contribution.ContributionStatistics;
 
@@ -37,9 +38,11 @@ import org.zanata.rest.dto.stats.contribution.ContributionStatistics;
  * @author Carlos Munoz <a
  *         href="mailto:camunoz@redhat.com">camunoz@redhat.com</a>
  */
+@Path(StatisticsResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-public interface StatisticsResource {
+public interface StatisticsResource extends RestResource {
     public static final String DATE_FORMAT = "yyyy-MM-dd";
 
     public static final String SERVICE_PATH = "/stats";

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/TranslatedDocResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/TranslatedDocResource.java
@@ -37,6 +37,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.jboss.resteasy.util.HttpHeaderNames;
 import org.zanata.common.LocaleId;
 import org.zanata.rest.dto.resource.TranslationsResource;
@@ -50,9 +51,11 @@ import static org.zanata.rest.service.SourceDocResource.RESOURCE_SLUG_TEMPLATE;
  *         href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
  *
  */
+@Path(TranslatedDocResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-public interface TranslatedDocResource {
+public interface TranslatedDocResource extends RestResource {
     public static final String SERVICE_PATH =
             ProjectIterationResource.SERVICE_PATH + "/r";
 

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/TranslationMemoryResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/TranslationMemoryResource.java
@@ -36,6 +36,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.zanata.common.LocaleId;
 
 /**
@@ -44,9 +45,11 @@ import org.zanata.common.LocaleId;
  * @author Sean Flanigan <a
  *         href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
  */
+@Path(TranslationMemoryResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Produces({ MediaType.APPLICATION_XML /* , "application/x-tmx" */})
 @Consumes({ MediaType.APPLICATION_XML /* , "application/x-tmx" */})
-public interface TranslationMemoryResource {
+public interface TranslationMemoryResource extends RestResource {
     public static final String SERVICE_PATH = "/tm";
 
     public static final String PREFERRED_MEDIA_TYPE = MediaType.APPLICATION_XML;

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/VersionResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/VersionResource.java
@@ -22,18 +22,21 @@ package org.zanata.rest.service;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.codehaus.enunciate.jaxrs.TypeHint;
+import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.zanata.rest.MediaTypes;
 import org.zanata.rest.dto.VersionInfo;
 
-@org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle
+@Path(VersionResource.SERVICE_PATH)
+@ExternallyManagedLifecycle
 @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
 @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-public interface VersionResource {
+public interface VersionResource extends RestResource {
     public static final String SERVICE_PATH = "/version";
 
     /**


### PR DESCRIPTION
Once the server is updated, it will be possible to remove the entire directory `zanata-common-api/src/main/java/org/zanata/rest/enunciate`.

Allows https://github.com/zanata/zanata-server/pull/1118