### PR TITLE
feat(ZNTA-1023): add FileTypeInfo

### DIFF
--- a/zanata-common-api/pom.xml
+++ b/zanata-common-api/pom.xml
@@ -42,6 +42,21 @@
 
     <plugins>
 
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <rules>
+            <bannedDependencies>
+              <excludes combine.children="append">
+                <!-- For GWT compatibility, stick to guava -->
+                <exclude>commons-lang:commons-lang</exclude>
+                <exclude>org.apache.commons:commons-lang3</exclude>
+              </excludes>
+            </bannedDependencies>
+          </rules>
+        </configuration>
+      </plugin>
+
       <!--
          This config is used when running mvn enunciate:docs.
          Docs will be generated in target/enunciate/build/docs/rest-api-docs.
@@ -306,12 +321,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.3.2</version>
-    </dependency>
-
-    <dependency>
       <!-- we still need this because the annotation must present in the
        interface/dto otherwise RESTEasy server implementation won't work-->
       <groupId>org.jboss.resteasy</groupId>
@@ -362,14 +371,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/zanata-common-api/src/main/java/org/zanata/common/DocumentType.java
+++ b/zanata-common-api/src/main/java/org/zanata/common/DocumentType.java
@@ -22,7 +22,6 @@ package org.zanata.common;
 
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -90,7 +89,7 @@ public enum DocumentType {
     }
 
     public static @Nullable DocumentType getByName(@Nullable String name) {
-        if (isBlank(name)) {
+        if (name == null || name.isEmpty()) {
             return null;
         }
         try {

--- a/zanata-common-api/src/main/java/org/zanata/common/DocumentType.java
+++ b/zanata-common-api/src/main/java/org/zanata/common/DocumentType.java
@@ -22,6 +22,7 @@ package org.zanata.common;
 
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -89,7 +90,7 @@ public enum DocumentType {
     }
 
     public static @Nullable DocumentType getByName(@Nullable String name) {
-        if (name == null) {
+        if (isBlank(name)) {
             return null;
         }
         try {

--- a/zanata-common-api/src/main/java/org/zanata/common/DocumentType.java
+++ b/zanata-common-api/src/main/java/org/zanata/common/DocumentType.java
@@ -32,6 +32,19 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/**
+ * NB: DocumentType should only be used by Zanata Server, not client code.
+ * Represents a file type supported by Zanata, with an associated list of file extensions.
+ * Note that the list of file types and default extensions, as supported by a
+ * given Zanata server, may be different from the list in this enum.
+ * <p>
+ *     Zanata's FileResource REST service has a function fileTypeInfoList(),
+ *     which returns information about which file types are actually supported
+ *     by the server.
+ * </p>
+ * @see FileTypeInfo
+ */
+// TODO move this to server, not api
 public enum DocumentType {
 
     GETTEXT(buildPotMap()),
@@ -47,7 +60,7 @@ public enum DocumentType {
 
     SUBTITLE("srt", "sbt", "sub", "vtt"),
     PROPERTIES("properties"), PROPERTIES_UTF8("properties"),
-    XML("xml"), XLIFF("xml"), TS("ts");
+    XML("xml"), XLIFF("xlf"), TS("ts");
 
     private static final Set<String> allSourceExtensions = buildExtensionsList(true);
 
@@ -57,6 +70,10 @@ public enum DocumentType {
         Map<String, String> potMap = new HashMap<>();
         potMap.put("pot", "po");
         return unmodifiableMap(potMap);
+    }
+
+    public FileTypeInfo toFileTypeInfo() {
+        return new FileTypeInfo(new FileTypeName(this.name()), this.extensions);
     }
 
     private static Set<String> buildExtensionsList(boolean source) {
@@ -71,10 +88,13 @@ public enum DocumentType {
         return unmodifiableSet(allExtensions);
     }
 
-    public static @Nullable DocumentType getByName(String name) {
+    public static @Nullable DocumentType getByName(@Nullable String name) {
+        if (name == null) {
+            return null;
+        }
         try {
             return DocumentType.valueOf(name.toUpperCase());
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             return null;
         }
     }
@@ -121,17 +141,9 @@ public enum DocumentType {
     private final Map<String, String> extensions;
 
     /**
-     * Create a document type enum constant with the given list of extensions.
-     * At least one extension must be specified.
-     *
-     * @throws IllegalArgumentException
-     *             if no extensions are specified
+     * Create a document type enum constant with the given list of default extensions.
      */
     DocumentType(@Nonnull String... extensions) throws IllegalArgumentException {
-        if (extensions.length == 0) {
-            throw new IllegalArgumentException(
-                "DocumentType must be constructed with at least one extension.");
-        }
         Map<String, String> extensionsMap = new HashMap<>();
         for (String extension : extensions) {
             extensionsMap.put(extension, extension);
@@ -140,17 +152,9 @@ public enum DocumentType {
     }
 
     /**
-     * Create a document type enum constant with the given list of extensions.
-     * At least one extension must be specified.
-     *
-     * @throws IllegalArgumentException
-     *             if no extensions are specified
+     * Create a document type enum constant with the given list of default extensions.
      */
     DocumentType(@Nonnull Map<String, String> extensions) throws IllegalArgumentException {
-        if (extensions.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "DocumentType must be constructed with at least one extension.");
-        }
         this.extensions = unmodifiableMap(extensions);
     }
 

--- a/zanata-common-api/src/main/java/org/zanata/common/FileTypeInfo.java
+++ b/zanata-common-api/src/main/java/org/zanata/common/FileTypeInfo.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.zanata.common;
+
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+
+import static java.util.Collections.unmodifiableCollection;
+import static java.util.Collections.unmodifiableMap;
+import static java.util.Collections.unmodifiableSet;
+
+/**
+ * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
+ */
+@ParametersAreNonnullByDefault
+public class FileTypeInfo implements Serializable {
+    /** Name of the DocumentType. NS: This may not correspond to a DocumentType
+     * recognised by the client (eg if server is newer).
+     * @see DocumentType
+     */
+    private final FileTypeName type;
+    /**
+     * Default file extensions for this type. Keys are source extensions, values are target extensions.
+     */
+    private final Map<String, String> extensions;
+
+    public FileTypeInfo(
+            @JsonProperty("type") FileTypeName type,
+            @JsonProperty("extensions") Map<String, String> extensions) {
+        this.type = type;
+        this.extensions = unmodifiableMap(extensions);
+    }
+
+    public FileTypeName getType() {
+        return type;
+    }
+
+    public Map<String, String> getExtensions() {
+        return extensions;
+    }
+
+    @JsonIgnore
+    public Collection<String> getSourceExtensions() {
+        return unmodifiableSet(extensions.keySet());
+    }
+
+    @JsonIgnore
+    public Collection<String> getTranslationExtensions() {
+        return unmodifiableCollection(extensions.values());
+    }
+
+    public FileTypeInfo withExtensions(Map<String, String> extensions) {
+        return new FileTypeInfo(type, extensions);
+    }
+
+}

--- a/zanata-common-api/src/main/java/org/zanata/common/FileTypeName.java
+++ b/zanata-common-api/src/main/java/org/zanata/common/FileTypeName.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.zanata.common;
+
+import java.io.Serializable;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+/**
+ * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
+ */
+@ParametersAreNonnullByDefault
+public class FileTypeName implements Comparable<FileTypeName>, Serializable {
+    /** Name of the FileType/DocumentType. NS: This may not correspond to a
+     * FileType/DocumentType recognised by the client (eg if server is newer).
+     * @see DocumentType
+     */
+    private final String name;
+
+    public FileTypeName(@JsonProperty("name") String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    public int compareTo(FileTypeName o) {
+        return name.compareTo(o.getName());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof FileTypeName) {
+            FileTypeName o = (FileTypeName) obj;
+            return name.equals(o.getName());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+}

--- a/zanata-common-api/src/main/java/org/zanata/common/ProjectType.java
+++ b/zanata-common-api/src/main/java/org/zanata/common/ProjectType.java
@@ -25,6 +25,7 @@ import javax.xml.bind.annotation.XmlType;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.zanata.common.DocumentType.*;
 
 @XmlType(name = "projectTypeType")
@@ -41,11 +42,12 @@ public enum ProjectType {
      */
     public static ProjectType getValueOf(String projectType) throws Exception {
         // TODO change all values to upper case and use ProjectType.valueOf(projectType)
-        if (projectType != null && !projectType.isEmpty()) {
-            for (ProjectType pt : ProjectType.values()) {
-                if (pt.name().equalsIgnoreCase(projectType)) {
-                    return pt;
-                }
+        if (isBlank(projectType)) {
+            throw new Exception("No project type specified");
+        }
+        for (ProjectType pt : ProjectType.values()) {
+            if (pt.name().equalsIgnoreCase(projectType)) {
+                return pt;
             }
         }
         if (OBSOLETE_PROJECT_TYPE_RAW.equalsIgnoreCase(projectType)) {

--- a/zanata-common-api/src/main/java/org/zanata/common/ProjectType.java
+++ b/zanata-common-api/src/main/java/org/zanata/common/ProjectType.java
@@ -22,11 +22,8 @@ package org.zanata.common;
 
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static org.zanata.common.DocumentType.*;
 
@@ -43,6 +40,7 @@ public enum ProjectType {
      * @throws Exception
      */
     public static ProjectType getValueOf(String projectType) throws Exception {
+        // TODO change all values to upper case and use ProjectType.valueOf(projectType)
         if (projectType != null && !projectType.isEmpty()) {
             for (ProjectType pt : ProjectType.values()) {
                 if (pt.name().equalsIgnoreCase(projectType)) {
@@ -66,6 +64,7 @@ public enum ProjectType {
      * @return a list of file types or empty list if it's not a supported
      *         project type
      */
+    @Deprecated
     public static List<DocumentType> getSupportedSourceFileTypes(ProjectType type) {
         if (type != null) {
             switch (type) {
@@ -84,6 +83,7 @@ public enum ProjectType {
     /**
      * @return source file types/extensions that this project type uses
      */
+    @Deprecated
     public List<DocumentType> getSourceFileTypes() {
         switch (this) {
             case Utf8Properties:
@@ -97,10 +97,27 @@ public enum ProjectType {
                 return Arrays.asList(XML);
             case File:
                 return fileProjectSourceDocTypes();
+            default:
+                throw new IllegalStateException("unexpected value");
         }
-        throw new IllegalStateException("impossible");
     }
 
+    /**
+     * I think this list is meant to be similar or identical to TranslationFileServiceImpl.DOCTYPEMAP.keySet()
+     * <p>
+     * For some reason, this method returns a partial, hard-coded list of the
+     * file types supported by the server, except these (as of 3.9):
+     * OPEN_DOCUMENT_TEXT_FLAT
+     * OPEN_DOCUMENT_PRESENTATION_FLAT
+     * OPEN_DOCUMENT_SPREADSHEET_FLAT
+     * OPEN_DOCUMENT_GRAPHICS_FLAT
+     * OPEN_DOCUMENT_DATABASE
+     * OPEN_DOCUMENT_FORMULA
+     * XML
+     * </p>
+     * @return
+     */
+    @Deprecated
     public static List<DocumentType> fileProjectSourceDocTypes() {
         return Arrays.asList(XML_DOCUMENT_TYPE_DEFINITION,
             PLAIN_TEXT, IDML, HTML, OPEN_DOCUMENT_TEXT, OPEN_DOCUMENT_PRESENTATION,

--- a/zanata-common-api/src/main/java/org/zanata/common/ProjectType.java
+++ b/zanata-common-api/src/main/java/org/zanata/common/ProjectType.java
@@ -25,7 +25,6 @@ import javax.xml.bind.annotation.XmlType;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.zanata.common.DocumentType.*;
 
 @XmlType(name = "projectTypeType")
@@ -42,7 +41,7 @@ public enum ProjectType {
      */
     public static ProjectType getValueOf(String projectType) throws Exception {
         // TODO change all values to upper case and use ProjectType.valueOf(projectType)
-        if (isBlank(projectType)) {
+        if (projectType == null || projectType.isEmpty()) {
             throw new Exception("No project type specified");
         }
         for (ProjectType pt : ProjectType.values()) {

--- a/zanata-common-api/src/main/java/org/zanata/rest/ElemSet.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/ElemSet.java
@@ -1,11 +1,12 @@
 package org.zanata.rest;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-
-import org.apache.commons.lang3.StringUtils;
 
 // NB don't add state in subclasses, or you will break the equals method
 public abstract class ElemSet<T> implements Set<T> {
@@ -17,7 +18,7 @@ public abstract class ElemSet<T> implements Set<T> {
     public ElemSet(String values) {
         impl = new HashSet<T>();
         if (values != null) {
-            String[] splitValues = StringUtils.split(values, ';');
+            Iterable<String> splitValues = Splitter.on(';').split(values);
             for (String val : splitValues) {
                 T elem = valueOfElem(val);
                 add(elem);
@@ -92,7 +93,7 @@ public abstract class ElemSet<T> implements Set<T> {
 
     @Override
     public String toString() {
-        return StringUtils.join(this, ";");
+        return Joiner.on(';').join(this);
     }
 
     // method is final because equals is final

--- a/zanata-common-api/src/main/java/org/zanata/rest/dto/extensions/gettext/HeaderEntry.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/dto/extensions/gettext/HeaderEntry.java
@@ -1,13 +1,13 @@
 package org.zanata.rest.dto.extensions.gettext;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
 
-import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jackson.annotate.JsonPropertyOrder;
 import org.zanata.rest.dto.DTOUtil;
 
@@ -68,8 +68,8 @@ public class HeaderEntry implements Serializable {
             return false;
 
         HeaderEntry other = (HeaderEntry) obj;
-        return StringUtils.equals(this.key, other.key)
-                && StringUtils.equals(this.value, other.value);
+        return Objects.equals(this.key, other.key)
+                && Objects.equals(this.value, other.value);
     }
 
     @Override

--- a/zanata-common-api/src/main/java/org/zanata/rest/dto/resource/ExtensionSet.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/dto/resource/ExtensionSet.java
@@ -6,16 +6,16 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.zanata.rest.dto.DTOUtil;
 import org.zanata.rest.dto.ExtensionValue;
+
+import javax.annotation.Nonnull;
 
 public class ExtensionSet<T extends ExtensionValue> extends
         AbstractCollection<T> implements Serializable {
 
     private static final long serialVersionUID = 1L;
-    private Map<Class<?>, T> extensions = new LinkedHashMap<Class<?>, T>();
+    private @Nonnull Map<Class<?>, T> extensions = new LinkedHashMap<>();
 
     @Override
     public Iterator<T> iterator() {
@@ -57,27 +57,20 @@ public class ExtensionSet<T extends ExtensionValue> extends
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        } else if (!(obj instanceof ExtensionSet)) {
-            return false;
-        } else {
-            @SuppressWarnings("rawtypes")
-            ExtensionSet other = (ExtensionSet) obj;
-
-            return new EqualsBuilder()
-                    .append(this.extensions, other.extensions).isEquals();
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
         }
+        if (o == null || !(o instanceof ExtensionSet)) {
+            return false;
+        }
+        ExtensionSet<?> that = (ExtensionSet<?>) o;
+        return extensions.equals(that.extensions);
     }
 
     @Override
     public int hashCode() {
-        HashCodeBuilder hcBuilder = new HashCodeBuilder(15, 67);
-        for (T t : this) {
-            hcBuilder.append(t);
-        }
-        return hcBuilder.toHashCode();
+        return extensions.hashCode();
     }
 
 }

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/FileResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/FileResource.java
@@ -21,7 +21,6 @@
 package org.zanata.rest.service;
 
 import java.util.List;
-import java.util.Map;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -36,6 +35,7 @@ import org.codehaus.enunciate.jaxrs.TypeHint;
 import org.codehaus.enunciate.modules.jersey.ExternallyManagedLifecycle;
 import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 import org.zanata.common.DocumentType;
+import org.zanata.common.FileTypeInfo;
 import org.zanata.rest.DocumentFileUploadForm;
 import org.zanata.rest.dto.ChunkUploadResponse;
 
@@ -52,6 +52,7 @@ public interface FileResource extends RestResource {
     public static final String FILE_RESOURCE = SERVICE_PATH;
     public static final String ACCEPTED_TYPES_RESOURCE = "/accepted_types";
     public static final String ACCEPTED_TYPE_LIST_RESOURCE = "/accepted_document_types";
+    public static final String FILE_TYPE_INFO_RESOURCE = "/doc_type_info";
     public static final String DOWNLOAD_TEMPLATE = "/download/{downloadId}";
     public static final String FILE_DOWNLOAD_TEMPLATE =
             "/translation/{projectSlug}/{iterationSlug}/{locale}/{fileType}";
@@ -84,8 +85,10 @@ public interface FileResource extends RestResource {
     public static final String FILETYPE_TRANSLATED_APPROVED = "baked";
 
     /**
-     * Deprecated.
-     * @see #acceptedFileTypeList
+     * Deprecated. Returns the source file extensions supported by the server.
+     * @return a semicolon-separated list of file extensions
+     * @see DocumentType#getSourceExtensions()
+     * @see #fileTypeInfoList()
      */
     @Deprecated
     @GET
@@ -95,12 +98,35 @@ public interface FileResource extends RestResource {
             public
             Response acceptedFileTypes();
 
+    /**
+     * Deprecated. A list of document types supported by the server. The result
+     * will not be deserializable if the server supports document types which
+     * the client does not know about (eg compiled against a newer version of
+     * zanata-api), also any changes to the list of supported file extensions
+     * for existing types will not be visible to the client.
+     * @return a List of DocumentType
+     * @see DocumentType
+     * @see #fileTypeInfoList()
+     */
+    @Deprecated
     @GET
     @Path(ACCEPTED_TYPE_LIST_RESOURCE)
     @Produces(MediaType.APPLICATION_JSON)
     @TypeHint(List.class)
     public
     Response acceptedFileTypeList();
+
+    /**
+     * A list of document types supported by the server, along with their
+     * default file extensions.
+     * @return a List of FileTypeInfo
+     * @see FileTypeInfo
+     */
+    @GET
+    @Path(FILE_TYPE_INFO_RESOURCE)
+    @Produces(MediaType.APPLICATION_JSON)
+    @TypeHint(List.class)
+    Response fileTypeInfoList();
 
     @POST
     @Path(SOURCE_UPLOAD_TEMPLATE)

--- a/zanata-common-api/src/main/java/org/zanata/rest/service/FileResource.java
+++ b/zanata-common-api/src/main/java/org/zanata/rest/service/FileResource.java
@@ -52,7 +52,7 @@ public interface FileResource extends RestResource {
     public static final String FILE_RESOURCE = SERVICE_PATH;
     public static final String ACCEPTED_TYPES_RESOURCE = "/accepted_types";
     public static final String ACCEPTED_TYPE_LIST_RESOURCE = "/accepted_document_types";
-    public static final String FILE_TYPE_INFO_RESOURCE = "/doc_type_info";
+    public static final String FILE_TYPE_INFO_RESOURCE = "/file_type_info";
     public static final String DOWNLOAD_TEMPLATE = "/download/{downloadId}";
     public static final String FILE_DOWNLOAD_TEMPLATE =
             "/translation/{projectSlug}/{iterationSlug}/{locale}/{fileType}";

--- a/zanata-common-api/src/test/java/org/zanata/common/DocumentTypeTest.java
+++ b/zanata-common-api/src/test/java/org/zanata/common/DocumentTypeTest.java
@@ -36,6 +36,7 @@ public class DocumentTypeTest {
     @Test
     public void typeForExtantType() {
         assertThat(fromSourceExtension("txt"), contains(PLAIN_TEXT));
+        assertThat(fromSourceExtension("srt"), contains(SUBTITLE));
     }
 
     @Test
@@ -68,7 +69,7 @@ public class DocumentTypeTest {
                 containsInAnyOrder("pot", "txt", "dtd", "idml", "html",
                         "htm", "odt", "fodt", "odp", "fodp", "ods", "fods",
                         "odg", "fodg", "odb", "odf", "srt", "sbt", "sub",
-                        "vtt", "properties", "xml", "ts"));
+                        "vtt", "properties", "xlf", "xml", "ts"));
     }
 
     @Test
@@ -80,7 +81,7 @@ public class DocumentTypeTest {
             containsInAnyOrder("po", "txt", "dtd", "idml", "html",
                 "htm", "odt", "fodt", "odp", "fodp", "ods", "fods",
                 "odg", "fodg", "odb", "odf", "srt", "sbt", "sub",
-                "vtt", "properties", "xml", "ts"));
+                "vtt", "properties", "xlf", "xml", "ts"));
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/zanata-common-api/src/test/java/org/zanata/common/ProjectTypeTest.java
+++ b/zanata-common-api/src/test/java/org/zanata/common/ProjectTypeTest.java
@@ -100,7 +100,7 @@ public class ProjectTypeTest {
         assertThat(extensions,
             containsInAnyOrder("dtd", "txt", "idml", "htm", "html", "odt",
                 "odp", "ods", "odg", "srt", "sbt", "sub", "vtt",
-                "properties", "xml", "pot", "ts"));
+                "properties", "xlf", "pot", "ts"));
     }
 
     @Test


### PR DESCRIPTION
- add FileTypeInfo/Name to transfer DocumentType info over JSON
- add FileResource.fileTypeInfoList() REST endpoint
- deprecate FileResource.acceptedFileTypeList()
- allow DocumentType with no default file extensions
- add default extension for XLIFF (.xlf)

See https://github.com/zanata/zanata-client/pull/113 and https://github.com/zanata/zanata-server/pull/1244

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-api/56)
<!-- Reviewable:end -->
